### PR TITLE
Add --file Option to ioc_scanner.py and Clarify Help Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ ansible --inventory=hosts-file cool-servers --module-name=script \
 --user="ian.kilmister"
 ```
 
+Optionally you can use the `--file` option to use a file on the remote host as a
+source for hashes.
+
+```console
+ansible --inventory=hosts-file cool-servers --module-name=script \
+--args="src/ioc_scan/ioc_scanner.py --file hash_file.txt" --become \
+--ask-become-pass --user="ian.kilmister"
+```
+
 ## Contributing ##
 
 We welcome contributions!  Please see [here](CONTRIBUTING.md) for

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
             # to never grab the regression version.
             "coveralls != 1.11.0",
             "coverage",
+            "pyfakefs",
             "pytest-cov",
             "pytest",
         ]

--- a/src/ioc_scan/ioc_scan_cli.py
+++ b/src/ioc_scan/ioc_scan_cli.py
@@ -14,11 +14,11 @@ Usage:
 
 Options:
   -h --help              Show this message.
-  -f --file=hashfile     Search for hashes in specified file.
+  -f --file=hashfile     Get IOC hashes from specified file.
   -L --log-level=LEVEL   If specified, then the log level will be set to
                          the specified value.  Valid values are "debug", "info",
                          "warning", "error", and "critical". [default: warning]
-  -s --stdin             Search for hashes on stdin.
+  -s --stdin             Get IOC hashes from stdin.
   -t --target=root       Scan target root directory. [default: /]
 """
 

--- a/src/ioc_scan/ioc_scan_cli.py
+++ b/src/ioc_scan/ioc_scan_cli.py
@@ -60,7 +60,7 @@ def main():
         with open(args["--file"]) as f:
             hashblob = f.read()
 
-    exit_code = ioc_scanner.main(hashblob, args["--target"])
+    exit_code = ioc_scanner.ioc_search(hashblob, args["--target"])
 
     # Stop logging and clean up
     logging.shutdown()

--- a/src/ioc_scan/ioc_scanner.py
+++ b/src/ioc_scan/ioc_scanner.py
@@ -163,7 +163,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Indicators of compromise (IoC) scanning tool."
     )
-    parser.add_argument("-f", "--file", dest="hashfile")
+    parser.add_argument(
+        "-f", "--file", dest="hashfile", help="Get IOC hashes from specified file."
+    )
     args = parser.parse_args()
 
     if args.hashes_file:

--- a/src/ioc_scan/ioc_scanner.py
+++ b/src/ioc_scan/ioc_scanner.py
@@ -96,8 +96,8 @@ def hash_file(file):
     return tuple(hasher.hexdigest() for hasher in hashers)
 
 
-def main(blob=None, root="/"):
-    """Start scanning, main entry point."""
+def ioc_search(blob=None, root="/"):
+    """Start scanning, typical entry point."""
     # start the clock
     start_time = datetime.utcnow()
 
@@ -157,7 +157,8 @@ def main(blob=None, root="/"):
     return 0
 
 
-if __name__ == "__main__":
+def main():
+    """Provide limited commandline functionality for standalone mode."""
     import argparse
 
     parser = argparse.ArgumentParser(
@@ -167,11 +168,16 @@ if __name__ == "__main__":
         "-f", "--file", dest="hashfile", help="Get IOC hashes from specified file."
     )
     args = parser.parse_args()
-
     if args.hashfile:
         logging.debug("Reading hashes from %s", args.hashfile)
         with open(args.hashfile) as f:
             hashblob = f.read()
-        sys.exit(main(hashblob))
+        exit_code = ioc_search(hashblob)
     else:
-        sys.exit(main())
+        exit_code = ioc_search()
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ioc_scan/ioc_scanner.py
+++ b/src/ioc_scan/ioc_scanner.py
@@ -158,4 +158,18 @@ def main(blob=None, root="/"):
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Indicators of compromise (IoC) scanning tool."
+    )
+    parser.add_argument("-f", "--file", dest="hashfile")
+    args = parser.parse_args()
+
+    if args.hashes_file:
+        logging.debug("Reading hashes from %s", args.hashfile)
+        with open(args.hashfile) as f:
+            hashblob = f.read()
+        sys.exit(main(hashblob))
+    else:
+        sys.exit(main())

--- a/src/ioc_scan/ioc_scanner.py
+++ b/src/ioc_scan/ioc_scanner.py
@@ -159,6 +159,7 @@ def ioc_search(blob=None, root="/"):
 
 def main():
     """Provide limited commandline functionality for standalone mode."""
+    # Standard Python Libraries
     import argparse
 
     parser = argparse.ArgumentParser(

--- a/src/ioc_scan/ioc_scanner.py
+++ b/src/ioc_scan/ioc_scanner.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    if args.hashes_file:
+    if args.hashfile:
         logging.debug("Reading hashes from %s", args.hashfile)
         with open(args.hashfile) as f:
             hashblob = f.read()

--- a/src/ioc_scan/ioc_scanner.py
+++ b/src/ioc_scan/ioc_scanner.py
@@ -169,11 +169,12 @@ def main():
     )
     args = parser.parse_args()
     if args.hashfile:
-        logging.debug("Reading hashes from %s", args.hashfile)
+        logging.debug("Reading hashes from '%s'.", args.hashfile)
         with open(args.hashfile) as f:
             hashblob = f.read()
         exit_code = ioc_search(hashblob)
     else:
+        logging.debug("Searching with default configuration.")
         exit_code = ioc_search()
 
     return exit_code

--- a/tests/test_ioc_scan.py
+++ b/tests/test_ioc_scan.py
@@ -75,6 +75,8 @@ def test_hash_file_except():
 
 def test_scan_file(capsys):
     """Test running the scanner with an input target file."""
+    test_hash = "69630e4574ec6798239b091cda43dca0"
+
     with patch.object(
         sys,
         "argv",
@@ -92,8 +94,11 @@ def test_scan_file(capsys):
         captured.out.count("eicar.txt") == 1
     ), "standard out should contain eicar detection with filename"
     assert (
-        captured.out.count("69630e4574ec6798239b091cda43dca0") == 2
-    ), "standard out should detection and tally should match hash"
+        captured.out.count(test_hash) == 2
+    ), "standard out detection and tally should match hash"
+    assert (
+        captured.out.count(f"{test_hash}    1") == 1
+    ), "standard out should show one detected match for the test file"
 
 
 def test_scan_stdin(capsys):
@@ -111,10 +116,10 @@ def test_scan_stdin(capsys):
     ), "standard out should contain eicar detection with filename"
     assert (
         captured.out.count(test_hash) == 2
-    ), "standard out should detection and tally should match hash"
+    ), "standard out detection and tally should match hash"
     assert (
         captured.out.count(f"{test_hash}    1") == 1
-    ), "standard out should show one detected match for test file"
+    ), "standard out should show one detected match for the test file"
 
 
 @pytest.fixture
@@ -127,6 +132,8 @@ def test_fs(fs):
 
 def test_ioc_scanner_standalone_no_file(capsys, test_fs):
     """Test running the scanner in standalone mode."""
+    test_hash = "69630e4574ec6798239b091cda43dca0"
+
     with patch.object(
         sys, "argv", ["bogus"],
     ):
@@ -137,12 +144,17 @@ def test_ioc_scanner_standalone_no_file(capsys, test_fs):
         captured.out.count("eicar.txt") == 1
     ), "standard out should contain eicar detection with filename"
     assert (
-        captured.out.count("69630e4574ec6798239b091cda43dca0") == 2
-    ), "standard out should detection and tally should match hash"
+        captured.out.count(test_hash) == 2
+    ), "standard out detection and tally should match hash"
+    assert (
+        captured.out.count(f"{test_hash}    1") == 1
+    ), "standard out should show one detected match for the test file"
 
 
 def test_ioc_scanner_standalone_file(capsys, test_fs):
     """Test running the scanner in standalone mode with an input target file."""
+    test_hash = "69630e4574ec6798239b091cda43dca0"
+
     with patch.object(
         sys, "argv", ["bogus", "--file=tests/testblob.txt"],
     ):
@@ -153,5 +165,8 @@ def test_ioc_scanner_standalone_file(capsys, test_fs):
         captured.out.count("eicar.txt") == 1
     ), "standard out should contain eicar detection with filename"
     assert (
-        captured.out.count("69630e4574ec6798239b091cda43dca0") == 2
-    ), "standard out should detection and tally should match hash"
+        captured.out.count(test_hash) == 2
+    ), "standard out detection and tally should match hash"
+    assert (
+        captured.out.count(f"{test_hash}    1") == 1
+    ), "standard out should show one detected match for the test file"

--- a/tests/test_ioc_scan.py
+++ b/tests/test_ioc_scan.py
@@ -23,6 +23,10 @@ log_levels = (
     pytest.param("critical2", marks=pytest.mark.xfail),
 )
 
+TEST_HASHFILE = "tests/testblob.txt"
+EICAR_MD5 = "69630e4574ec6798239b091cda43dca0"
+LOREM_SHA256 = "56293a80e0394d252e995f2debccea8223e4b5b2b150bee212729b3b39ac4d46"
+
 
 def test_version(capsys):
     """Verify that version string sent to stdout, and agrees with the module."""
@@ -75,15 +79,13 @@ def test_hash_file_except():
 
 def test_scan_file(capsys):
     """Test running the scanner with an input target file."""
-    test_hash = "69630e4574ec6798239b091cda43dca0"
-
     with patch.object(
         sys,
         "argv",
         [
             "bogus",
             "--log-level=debug",
-            "--file=tests/testblob.txt",
+            f"--file={TEST_HASHFILE}",
             "--target=tests/targets",
         ],
     ):
@@ -94,31 +96,30 @@ def test_scan_file(capsys):
         captured.out.count("eicar.txt") == 1
     ), "standard out should contain eicar detection with filename"
     assert (
-        captured.out.count(test_hash) == 2
+        captured.out.count(EICAR_MD5) == 2
     ), "standard out detection and tally should match hash"
     assert (
-        captured.out.count(f"{test_hash}    1") == 1
+        captured.out.count(f"{EICAR_MD5}    1") == 1
     ), "standard out should show one detected match for the test file"
 
 
 def test_scan_stdin(capsys):
     """Test running the scanner with stdin as input."""
-    test_hash = "69630e4574ec6798239b091cda43dca0"
     with patch.object(
         sys, "argv", ["bogus", "--log-level=debug", "--stdin", "--target=tests/targets"]
     ):
-        with patch("sys.stdin", StringIO(test_hash)):
+        with patch("sys.stdin", StringIO(LOREM_SHA256)):
             ioc_scan_cli.main()
     captured = capsys.readouterr()
     print(captured.out)
     assert (
-        captured.out.count("eicar.txt") == 1
+        captured.out.count("lorem.txt") == 1
     ), "standard out should contain eicar detection with filename"
     assert (
-        captured.out.count(test_hash) == 2
+        captured.out.count(LOREM_SHA256) == 2
     ), "standard out detection and tally should match hash"
     assert (
-        captured.out.count(f"{test_hash}    1") == 1
+        captured.out.count(f"{LOREM_SHA256}    1") == 1
     ), "standard out should show one detected match for the test file"
 
 
@@ -132,8 +133,6 @@ def test_fs(fs):
 
 def test_ioc_scanner_standalone_no_file(caplog, capsys, test_fs):
     """Test running the scanner in standalone mode."""
-    test_hash = "69630e4574ec6798239b091cda43dca0"
-
     with caplog.at_level(logging.DEBUG):
         with patch.object(
             sys, "argv", ["bogus"],
@@ -154,21 +153,18 @@ def test_ioc_scanner_standalone_no_file(caplog, capsys, test_fs):
         captured.out.count("eicar.txt") == 1
     ), "standard out should contain eicar detection with filename"
     assert (
-        captured.out.count(test_hash) == 2
+        captured.out.count(EICAR_MD5) == 2
     ), "standard out detection and tally should match hash"
     assert (
-        captured.out.count(f"{test_hash}    1") == 1
+        captured.out.count(f"{EICAR_MD5}    1") == 1
     ), "standard out should show one detected match for the test file"
 
 
 def test_ioc_scanner_standalone_file(caplog, capsys, test_fs):
     """Test running the scanner in standalone mode with an input target file."""
-    test_hash = "69630e4574ec6798239b091cda43dca0"
-    hashfile = "tests/testblob.txt"
-
     with caplog.at_level(logging.DEBUG):
         with patch.object(
-            sys, "argv", ["bogus", f"--file={hashfile}"],
+            sys, "argv", ["bogus", f"--file={TEST_HASHFILE}"],
         ):
             ioc_scanner.main()
 
@@ -178,17 +174,17 @@ def test_ioc_scanner_standalone_file(caplog, capsys, test_fs):
     ), "logging output should show reading IOC hashes from a file"
 
     assert (
-        f"Reading hashes from '{hashfile}'." in caplog.text
+        f"Reading hashes from '{TEST_HASHFILE}'." in caplog.text
     ), "logging output should show reading IOC hashes from a file"
 
     captured = capsys.readouterr()
     print(captured.out)
     assert (
-        captured.out.count("eicar.txt") == 1
+        captured.out.count("lorem.txt") == 1
     ), "standard out should contain eicar detection with filename"
     assert (
-        captured.out.count(test_hash) == 2
+        captured.out.count(LOREM_SHA256) == 2
     ), "standard out detection and tally should match hash"
     assert (
-        captured.out.count(f"{test_hash}    1") == 1
+        captured.out.count(f"{LOREM_SHA256}    1") == 1
     ), "standard out should show one detected match for the test file"

--- a/tests/test_ioc_scan.py
+++ b/tests/test_ioc_scan.py
@@ -130,14 +130,24 @@ def test_fs(fs):
     yield fs
 
 
-def test_ioc_scanner_standalone_no_file(capsys, test_fs):
+def test_ioc_scanner_standalone_no_file(caplog, capsys, test_fs):
     """Test running the scanner in standalone mode."""
     test_hash = "69630e4574ec6798239b091cda43dca0"
 
-    with patch.object(
-        sys, "argv", ["bogus"],
-    ):
-        ioc_scanner.main()
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(
+            sys, "argv", ["bogus"],
+        ):
+            ioc_scanner.main()
+
+    print(caplog.text)
+    assert (
+        "Searching with default configuration." in caplog.text
+    ), "logging output should show using the default configuration"
+    assert (
+        "Reading hashes from" not in caplog.text
+    ), "logging output should show using the default configuration"
+
     captured = capsys.readouterr()
     print(captured.out)
     assert (
@@ -151,14 +161,26 @@ def test_ioc_scanner_standalone_no_file(capsys, test_fs):
     ), "standard out should show one detected match for the test file"
 
 
-def test_ioc_scanner_standalone_file(capsys, test_fs):
+def test_ioc_scanner_standalone_file(caplog, capsys, test_fs):
     """Test running the scanner in standalone mode with an input target file."""
     test_hash = "69630e4574ec6798239b091cda43dca0"
+    hashfile = "tests/testblob.txt"
 
-    with patch.object(
-        sys, "argv", ["bogus", "--file=tests/testblob.txt"],
-    ):
-        ioc_scanner.main()
+    with caplog.at_level(logging.DEBUG):
+        with patch.object(
+            sys, "argv", ["bogus", f"--file={hashfile}"],
+        ):
+            ioc_scanner.main()
+
+    print(caplog.text)
+    assert (
+        "Searching with default configuration." not in caplog.text
+    ), "logging output should show reading IOC hashes from a file"
+
+    assert (
+        f"Reading hashes from '{hashfile}'." in caplog.text
+    ), "logging output should show reading IOC hashes from a file"
+
     captured = capsys.readouterr()
     print(captured.out)
     assert (

--- a/tests/testblob.txt
+++ b/tests/testblob.txt
@@ -5,3 +5,5 @@ GNU bash, version 4.4.12(1)-release (x86_64-pc-linux-gnu)
 ac56f4b8fac5739ccdb45777d313becf
 EICAR test file
 69630e4574ec6798239b091cda43dca0
+Lorem Ipsum testing file (SHA256)
+56293a80e0394d252e995f2debccea8223e4b5b2b150bee212729b3b39ac4d46


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This PR adds a `--file` option to `ioc_scanner.py` if it is run in a stand-alone style. It also clarifies the help for the `--file` and `--stdin` options in `ioc_scan_cli.py` to (hopefully) make it more clear what they do.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context

The misunderstanding of script functionality in #7 led to a problem and a use-case being discovered. This PR thus seeks to close #8 and #10 since they are related. This will hopefully improve the end user experience.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

Automated tests pass and I tested the stand-alone usage changes on the testing server I used for #11 . Without a `--target` option in `ioc_scanner.py` it is not feasible to add test coverage because it will scan from the root of the filesystem.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
