### PR TITLE
Remove pyfakefs Workaround for Missing /dev/null

### DIFF
--- a/tests/test_ioc_scan.py
+++ b/tests/test_ioc_scan.py
@@ -36,10 +36,6 @@ def test_fs(fs):
     fs.add_real_directory("tests/targets")
     fs.add_real_file("tests/testblob.txt")
 
-    # In the pytest 6.x release something has changed where the caplog fixture
-    # needs to access /dev/null as part of its operation. As a result we need to
-    # manually create it in the fake filesystem.
-    fs.create_file("dev/null")
     yield fs
 
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR removes the manual creation of `/dev/null` that was added in #15 to resolve issues with [pytest v6](https://github.com/pytest-dev/pytest/releases).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

I saw that on 2020-12-25 the [apb](https://github.com/cisagov/action-apb) requested [GitHub Actions run failed](https://github.com/cisagov/ioc-scanner/runs/1608956328?check_suite_focus=true#step:6:34). Upon investigation I saw that [pyfakefs v4.3.3](https://github.com/jmcgeheeiv/pyfakefs/releases/tag/v4.3.3) was released on 2020-12-20. Digging into the changes I saw that in https://github.com/jmcgeheeiv/pyfakefs/commit/f1e5163665e900bff09c21a86f6e05e547c1b3cf they fixed the null device name (`/dev/nul -> /dev/null`), which is likely why we had to manually create it previously.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Tests pass as expected again.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
