### PR TITLE
Add a debug flag to the `ioc_scanner.py` stand-alone functionality

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @felddy @mcdonnnj
+* @dav3r @felddy @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/src/ioc_scan/_version.py
+++ b/src/ioc_scan/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/src/ioc_scan/ioc_scanner.py
+++ b/src/ioc_scan/ioc_scanner.py
@@ -165,9 +165,22 @@ def main():
         description="Indicators of compromise (IoC) scanning tool."
     )
     parser.add_argument(
+        "-d",
+        "--debug",
+        dest="debug_output",
+        action="store_true",
+        help="Enable debug logging output.",
+    )
+    parser.add_argument(
         "-f", "--file", dest="hashfile", help="Get IOC hashes from specified file."
     )
     args = parser.parse_args()
+
+    logging.basicConfig(
+        format="%(asctime)-15s %(levelname)s %(message)s",
+        level=logging.DEBUG if args.debug_output else logging.INFO,
+    )
+
     if args.hashfile:
         logging.debug("Reading hashes from '%s'.", args.hashfile)
         with open(args.hashfile) as f:

--- a/src/ioc_scan/ioc_scanner.py
+++ b/src/ioc_scan/ioc_scanner.py
@@ -169,10 +169,10 @@ def main():
         "--debug",
         dest="debug_output",
         action="store_true",
-        help="Enable debug logging output.",
+        help="enable debug logging output",
     )
     parser.add_argument(
-        "-f", "--file", dest="hashfile", help="Get IOC hashes from specified file."
+        "-f", "--file", dest="hashfile", help="get IOC hashes from specified file"
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a `-d` / `--debug` flag to the stand-alone functionality of `ioc_scanner.py` to enable debug level logging.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I was helping @bra1ncramp troubleshoot an issue with using this library with the stand-alone through Ansible method. The configuration of `ioc_scanner.py` does not provide any output until it has completed running by default and there was no way to view the debug logging messages.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I tested that the argument works as expected to adjust the display of `logging` messages.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
