### PR TITLE
Improve search

### DIFF
--- a/extras/ioc_scan_by_host.sh
+++ b/extras/ioc_scan_by_host.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# Search for indicator of compromise (IOC) strings on a list of AWS instances
-# via SSM.  The filename specified in the first argument (ioc-file)
-# should contain a list of IOC strings, one per line.
+# Search for indicator of compromise (IOC) strings on a list of AWS
+# instances via SSM.  The filename specified in the first argument
+# (ioc-file) should contain a list of IOC strings, one per line.
 #
 # Usage: ./ioc_scan_by_host.sh ioc-file <instance-id>...
 
@@ -21,8 +21,8 @@ if [ ! -f "$1" ]; then
   exit 1
 fi
 
-# Read IOC strings from file.  [[ -n "$line" ]] handles the case where the last
-# line doesn't end with a newline.
+# Read IOC strings from file.  [[ -n "$line" ]] handles the case where
+# the last line doesn't end with a newline.
 iocList=()
 while IFS= read -r line || [[ -n "$line" ]]; do
   iocList+=("$line")
@@ -40,8 +40,8 @@ logfile="./$today-ioc-scan.log"
 exec > >(tee -ai "$logfile")
 exec 2> >(tee -ai "$logfile" >&2)
 
-# Get list of arguments passed to script, but ignore the first two (script name
-# and IOC file); the rest are the instance IDs.
+# Get list of arguments passed to script, but ignore the first two
+# (script name and IOC file); the rest are the instance IDs.
 instances=("${@:2}")
 
 echo IOC List is: "${iocList[*]}"

--- a/src/ioc_scan/ioc_scan_cli.py
+++ b/src/ioc_scan/ioc_scan_cli.py
@@ -2,7 +2,7 @@
 
 This script can take a blob of text that "should" contain MD5 hashes
 and scan a machine looking for files that match.  It will report the
-location of each mataching file as well as a summary containing the
+location of each matching file as well as a summary containing the
 tallies by hash.  Execution time is also reported.
 
 This script should be run as a priveledged user.


### PR DESCRIPTION
## 🗣 Description ##

This pull request improves the shell command run via `aws ssm start-session`.

It also fixes an unrelated typo.

## 💭 Motivation and context ##

`find-grep` should be a bit more efficient than the way the search for IoCs was being done before.  The old way required one more `grep` command in the pipe chain.

## 🧪 Testing ##

I used these changes to successfully run a search for some IoCs we received recently.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.