### PR TITLE
Improve keyword scans

### DIFF
--- a/extras/ioc_scan_by_host.sh
+++ b/extras/ioc_scan_by_host.sh
@@ -55,7 +55,7 @@ for instance_id in "${instances[@]}"; do
   # Use find-zgrep to search for IOC strings in log files (including
   # gzipped log files), ignoring *.journal files.  We pipe the result
   # into another grep process that uses the --invert-match grep flag
-  # to exclude matches (e.g., from sudo.log) that contain our grep
+  # to exclude matches (e.g. from sudo.log) that contain our zgrep
   # command (e.g. sudo.log).
   aws ssm start-session --target="$instance_id" \
     --document=AWS-StartInteractiveCommand \

--- a/extras/ioc_scan_by_host.sh
+++ b/extras/ioc_scan_by_host.sh
@@ -59,7 +59,7 @@ for instance_id in "${instances[@]}"; do
   # command (e.g. sudo.log).
   aws ssm start-session --target="$instance_id" \
     --document=AWS-StartInteractiveCommand \
-    --parameters="command='hostname; for i in ${iocList[*]}; do sudo find /var/log -type f -not -name \*\.journal -exec zgrep --ignore-case \$i {} \; | grep --invert-match -- --ignore-case\ --recursive\ | echo \$(wc --lines) found for \$i; done'"
+    --parameters="command='hostname; for i in ${iocList[*]}; do sudo find /var/log -type f -not -name \*\.journal -exec zgrep --ignore-case \$i {} \; | grep --invert-match -- grep\ --ignore-case | echo \$(wc --lines) found for \$i; done'"
 
   echo Search of "$instance_id" is complete.
 done

--- a/extras/ioc_scan_by_host.sh
+++ b/extras/ioc_scan_by_host.sh
@@ -59,7 +59,7 @@ for instance_id in "${instances[@]}"; do
   # command (e.g. sudo.log).
   aws ssm start-session --target="$instance_id" \
     --document=AWS-StartInteractiveCommand \
-    --parameters="command='hostname; for i in ${iocList[*]}; do sudo find /var/log -type f -not -name \*\.journal -exec zgrep --ignore-case \$i {} \; | grep --invert-match -- grep\ --ignore-case | echo \$(wc --lines) found for \$i; done'"
+    --parameters="command='hostname; for i in ${iocList[*]}; do sudo find /var/log -type f -not -name \*\.journal -exec zgrep --ignore-case \$i {} \; | grep --invert-match -- zgrep\ --ignore-case | echo \$(wc --lines) found for \$i; done'"
 
   echo Search of "$instance_id" is complete.
 done

--- a/extras/ioc_scan_by_host.sh
+++ b/extras/ioc_scan_by_host.sh
@@ -50,7 +50,7 @@ echo Instances are: "${instances[*]}"
 # Loop through all instance IDs
 for instance_id in "${instances[@]}"; do
   echo
-  echo Searching "$instance_id":
+  echo -n Searching "$instance_id":
 
   # Use find-grep to search for IOC strings in log files, ignoring
   # *.journal files.  We pipe the result into another grep process
@@ -58,7 +58,7 @@ for instance_id in "${instances[@]}"; do
   # from sudo.log) that contain our grep command (e.g. sudo.log).
   aws ssm start-session --target="$instance_id" \
     --document=AWS-StartInteractiveCommand \
-    --parameters="command='for i in ${iocList[*]}; do sudo find /var/log -type f -not -name \*\.journal -exec zgrep --ignore-case --extended-regexp \$i {} \; | grep --invert-match -- --ignore-case\ --recursive\ --extended-regexp\ | echo \$(wc --lines) found for \$i; done'"
+    --parameters="command='hostname; for i in ${iocList[*]}; do sudo find /var/log -type f -not -name \*\.journal -exec zgrep --ignore-case --extended-regexp \$i {} \; | grep --invert-match -- --ignore-case\ --recursive\ --extended-regexp\ | echo \$(wc --lines) found for \$i; done'"
 
   echo Search of "$instance_id" is complete.
 done

--- a/extras/ioc_scan_by_host.sh
+++ b/extras/ioc_scan_by_host.sh
@@ -58,7 +58,7 @@ for instance_id in "${instances[@]}"; do
   # from sudo.log) that contain our grep command (e.g. sudo.log).
   aws ssm start-session --target="$instance_id" \
     --document=AWS-StartInteractiveCommand \
-    --parameters="command='for i in ${iocList[*]}; do sudo find /var/log -type f -not -name \*\.journal -exec grep --ignore-case --recursive \$i {} \; | grep --invert-match -- --ignore-case\ --recursive\ | echo \$(wc --lines) found for \$i; done'"
+    --parameters="command='for i in ${iocList[*]}; do sudo find /var/log -type f -not -name \*\.journal -exec zgrep --ignore-case --extended-regexp \$i {} \; | grep --invert-match -- --ignore-case\ --recursive\ --extended-regexp\ | echo \$(wc --lines) found for \$i; done'"
 
   echo Search of "$instance_id" is complete.
 done

--- a/extras/ioc_scan_by_host.sh
+++ b/extras/ioc_scan_by_host.sh
@@ -58,7 +58,7 @@ for instance_id in "${instances[@]}"; do
   # from sudo.log) that contain our grep command (e.g. sudo.log).
   aws ssm start-session --target="$instance_id" \
     --document=AWS-StartInteractiveCommand \
-    --parameters="command='hostname; for i in ${iocList[*]}; do sudo find /var/log -type f -not -name \*\.journal -exec zgrep --ignore-case --extended-regexp \$i {} \; | grep --invert-match -- --ignore-case\ --recursive\ --extended-regexp\ | echo \$(wc --lines) found for \$i; done'"
+    --parameters="command='hostname; for i in ${iocList[*]}; do sudo find /var/log -type f -not -name \*\.journal -exec zgrep --ignore-case \$i {} \; | grep --invert-match -- --ignore-case\ --recursive\ | echo \$(wc --lines) found for \$i; done'"
 
   echo Search of "$instance_id" is complete.
 done

--- a/extras/ioc_scan_by_host.sh
+++ b/extras/ioc_scan_by_host.sh
@@ -52,10 +52,11 @@ for instance_id in "${instances[@]}"; do
   echo
   echo -n Searching "$instance_id":
 
-  # Use find-grep to search for IOC strings in log files, ignoring
-  # *.journal files.  We pipe the result into another grep process
-  # that uses the --invert-match grep flag to exclude matches (e.g.,
-  # from sudo.log) that contain our grep command (e.g. sudo.log).
+  # Use find-zgrep to search for IOC strings in log files (including
+  # gzipped log files), ignoring *.journal files.  We pipe the result
+  # into another grep process that uses the --invert-match grep flag
+  # to exclude matches (e.g., from sudo.log) that contain our grep
+  # command (e.g. sudo.log).
   aws ssm start-session --target="$instance_id" \
     --document=AWS-StartInteractiveCommand \
     --parameters="command='hostname; for i in ${iocList[*]}; do sudo find /var/log -type f -not -name \*\.journal -exec zgrep --ignore-case \$i {} \; | grep --invert-match -- --ignore-case\ --recursive\ | echo \$(wc --lines) found for \$i; done'"


### PR DESCRIPTION
## 🗣 Description ##

This PR makes two changes:
* Outputs the hostname of each instance
* Uses `zgrep` search command. NOTE: `--recursive` is removed since it is not a valid flag for `zgrep`


## 💭 Motivation and context ##
* Providing the instance hostname gives more clarity in the log output, making it more useful in rolled-over logs
* Using `grep` to search for key words on instances will only reveal possible IOCs if the incident happened within the last rollover date for the log files.  Switching to `zgrep` enables us to search inside rolled-over (gzipped) log files increases the thoroughness of the scans, thus improving the utility of this script.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
