### PR TITLE
Automate hash scans

### DIFF
--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -134,7 +134,7 @@ for i in "${serverList[@]}"; do
 
   instanceName=$(getHost)
 
-  echo "Begining scan of Instance $i -- $instanceName" | tee -a "$logfile"
+  echo "Beginning scan of instance $i -- $instanceName" | tee --append "$logfile"
 
   # Start Port Forwarding
   echo "Begining port forwarding"

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -46,7 +46,7 @@ while IFS= read -r line || [[ -n "$line" ]]; do
 done < "$1"
 
 if [ ${#serverList[@]} -eq 0 ]; then
-  echo No Instances found in "$1" - exiting.
+  echo No instances found in "$1" - exiting.
   exit 1
 fi
 

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -35,20 +35,20 @@ if [ ! -f "$1" ]; then
   exit 1
 fi
 
-# Check if environmental variables are set
+# Check if environment variables are set
 CRED=$(env | grep AWS_SHARED_CREDENTIALS_FILE)
 REG=$(env | grep AWS_REGION)
 PROF=$(env | grep AWS_PROFILE)
 [[ -z "$CRED" ]] && {
-  echo "AWS_SHARED_CREDENTIALS_FILE environmental variable is not set."
+  echo "AWS_SHARED_CREDENTIALS_FILE environment variable is not set."
   exit 1
 }
 [[ -z "$REG" ]] && {
-  echo "AWS_REGION environmental variable is not set."
+  echo "AWS_REGION environment variable is not set."
   exit 1
 }
 [[ -z "$PROF" ]] && {
-  echo "AWS_PROFILE environmental variable is not set."
+  echo "AWS_PROFILE environment variable is not set."
   exit 1
 }
 

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -140,7 +140,7 @@ for i in "${serverList[@]}"; do
   echo "Beginning port forwarding (local port 5555 to remote port 6666)"
   portForward &
 
-  # Create ~/src/ioc_scan directory on Instance
+  # Create ~/src/ioc_scan directory on instance
   echo "Verifying ~/src/ioc_scan directory on $instanceName"
   AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
     aws --profile="$AWSPROF" --region="$AWS_REGION" \

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-##Add the hashes to the blob at src/ioc_scan/ioc_scanner.py
+# Add the hashes to the blob at src/ioc_scan/ioc_scanner.py
 #
 #
-#  The filename specified in the first argument
+# The filename specified in the first argument
 # (instance-list-file) should contain a list of instance id strings, one per line.
 #
 # Usage: ./ioc_hash_scan.sh instance-list-file <AWS_PROFILE>

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -6,8 +6,8 @@
 # The filename specified in the first argument
 # (instance-list-file) should contain a list of instance id strings, one per line.
 #
-# The following environmental varialbles must be set:
-# AWS_SHARED_CREDENTAILS_FILE
+# The following environment variables must be set:
+# AWS_SHARED_CREDENTIALS_FILE
 # AWS_REGION
 # AWS_PROFILE
 #

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -28,26 +28,26 @@ set -o pipefail
 pydir="../src/ioc_scan/"
 
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ] || [ $# -lt 2 ]; then
-	echo Usage: "$0" instance-list-file \<AWS_PROFILE\>
-	exit 1
+  echo Usage: "$0" instance-list-file \<AWS_PROFILE\>
+  exit 1
 fi
 
 # Check if instance list file exists.
 if [ ! -f "$1" ]; then
-	echo Instance List file "$1" does not exist - exiting.
-	exit 1
+  echo Instance List file "$1" does not exist - exiting.
+  exit 1
 fi
 
 # Read instance id strings from file.  [[ -n "$line" ]] handles the case where
 # the last line doesn't end with a newline.
 serverList=()
 while IFS= read -r line || [[ -n "$line" ]]; do
-	serverList+=("$line")
-done <"$1"
+  serverList+=("$line")
+done < "$1"
 
 if [ ${#serverList[@]} -eq 0 ]; then
-	echo No Instances found in "$1" - exiting.
-	exit 1
+  echo No Instances found in "$1" - exiting.
+  exit 1
 fi
 
 # Path of aws credentials file
@@ -63,125 +63,125 @@ exec 2> >(grep --invert-match 'SIGTERM')
 
 ## FUNCTIONS
 function getOSType() {
-	OSNAME=$(AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-		aws --profile="$AWSPROF" --region="$AWS_REGION" \
-		ssm start-session --target="$i" \
-		--document=AWS-StartInteractiveCommand \
-		--parameters="command=cat /etc/os-release | grep --extended-regexp ^NAME=" \
-		--output text)
-	echo "$OSNAME" | grep NAME | cut -d'"' -f2 | cut -d' ' -f1
+  OSNAME=$(AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+    aws --profile="$AWSPROF" --region="$AWS_REGION" \
+    ssm start-session --target="$i" \
+    --document=AWS-StartInteractiveCommand \
+    --parameters="command=cat /etc/os-release | grep --extended-regexp ^NAME=" \
+    --output text)
+  echo "$OSNAME" | grep NAME | cut -d'"' -f2 | cut -d' ' -f1
 }
 
 function getHost() {
-	HOST=$(AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-		aws --profile="$AWSPROF" --region="$AWS_REGION" \
-		ssm start-session --target="$i" \
-		--document=AWS-StartInteractiveCommand \
-		--parameters="command=hostname" \
-		--output text)
-	echo "$HOST" | grep --invert-match "session" | sed '/^$/d'
+  HOST=$(AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+    aws --profile="$AWSPROF" --region="$AWS_REGION" \
+    ssm start-session --target="$i" \
+    --document=AWS-StartInteractiveCommand \
+    --parameters="command=hostname" \
+    --output text)
+  echo "$HOST" | grep --invert-match "session" | sed '/^$/d'
 }
 
 function portForward() {
-	AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-		aws --profile="$AWSPROF" --region="$AWS_REGION" \
-		ssm start-session --target="$i" \
-		--document=AWS-StartPortForwardingSession --parameters="localPortNumber=5555,portNumber=6666"
+  AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+    aws --profile="$AWSPROF" --region="$AWS_REGION" \
+    ssm start-session --target="$i" \
+    --document=AWS-StartPortForwardingSession --parameters="localPortNumber=5555,portNumber=6666"
 }
 
 function installNC() {
-	if [[ "$OS" == "Debian" ]]; then
-		AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-			aws --profile="$AWSPROF" --region="$AWS_REGION" \
-			ssm start-session --target="$i" \
-			--document=AWS-StartInteractiveCommand \
-			--parameters="command='sudo apt-get install netcat -y'"
-	else
-		AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-			aws --profile="$AWSPROF" --region="$AWS_REGION" \
-			ssm start-session --target="$i" \
-			--document=AWS-StartInteractiveCommand \
-			--parameters="command='sudo yum install netcat -y'"
-	fi
+  if [[ "$OS" == "Debian" ]]; then
+    AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+      aws --profile="$AWSPROF" --region="$AWS_REGION" \
+      ssm start-session --target="$i" \
+      --document=AWS-StartInteractiveCommand \
+      --parameters="command='sudo apt-get install netcat -y'"
+  else
+    AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+      aws --profile="$AWSPROF" --region="$AWS_REGION" \
+      ssm start-session --target="$i" \
+      --document=AWS-StartInteractiveCommand \
+      --parameters="command='sudo yum install netcat -y'"
+  fi
 }
 
 function startListen() {
-	if [[ "$OS" == "Debian" ]]; then
-		AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-			aws --profile="$AWSPROF" --region="$AWS_REGION" \
-			ssm start-session --target="$i" \
-			--document=AWS-StartInteractiveCommand \
-			--parameters="command='cd ~/src/ioc_scan; nc -l -p 6666 | tar xzf -'"
-	else
-		AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-			aws --profile="$AWSPROF" --region="$AWS_REGION" \
-			ssm start-session --target="$i" \
-			--document=AWS-StartInteractiveCommand \
-			--parameters="command='cd ~/src/ioc_scan; nc -l 6666 | tar xzf -'"
-	fi
+  if [[ "$OS" == "Debian" ]]; then
+    AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+      aws --profile="$AWSPROF" --region="$AWS_REGION" \
+      ssm start-session --target="$i" \
+      --document=AWS-StartInteractiveCommand \
+      --parameters="command='cd ~/src/ioc_scan; nc -l -p 6666 | tar xzf -'"
+  else
+    AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+      aws --profile="$AWSPROF" --region="$AWS_REGION" \
+      ssm start-session --target="$i" \
+      --document=AWS-StartInteractiveCommand \
+      --parameters="command='cd ~/src/ioc_scan; nc -l 6666 | tar xzf -'"
+  fi
 }
 
 ## MAIN SCRIPT
-echo "IOC Hash Scan - $today-$(date +%H:%M:%S)" >"$logfile"
+echo "IOC Hash Scan - $today-$(date +%H:%M:%S)" > "$logfile"
 
 for i in "${serverList[@]}"; do
-	OS="$(getOSType)"
-	if [[ "$OS" != "Debian" && "$OS" != "Fedora" ]]; then
-		echo "Non-supported OS Type"
-		exit 1
-	fi
+  OS="$(getOSType)"
+  if [[ "$OS" != "Debian" && "$OS" != "Fedora" ]]; then
+    echo "Non-supported OS Type"
+    exit 1
+  fi
 
-	instanceName=$(getHost)
+  instanceName=$(getHost)
 
-	echo "Begining scan of Instance $i -- $instanceName" | tee -a "$logfile"
+  echo "Begining scan of Instance $i -- $instanceName" | tee -a "$logfile"
 
-	# Start Port Forwarding
-	echo "Begining port forwarding"
-	portForward &
+  # Start Port Forwarding
+  echo "Begining port forwarding"
+  portForward &
 
-	# Create ~/src/ioc_scan directory on Instance
-	echo "Verifying ~/src/ioc_scan directory on $instanceName"
-	AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-		aws --profile="$AWSPROF" --region="$AWS_REGION" \
-		ssm start-session --target="$i" \
-		--document=AWS-StartInteractiveCommand \
-		--parameters="command='if [ ! -d ~/src/ioc_scan ]; then mkdir -p ~/src/ioc_scan; fi'"
+  # Create ~/src/ioc_scan directory on Instance
+  echo "Verifying ~/src/ioc_scan directory on $instanceName"
+  AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+    aws --profile="$AWSPROF" --region="$AWS_REGION" \
+    ssm start-session --target="$i" \
+    --document=AWS-StartInteractiveCommand \
+    --parameters="command='if [ ! -d ~/src/ioc_scan ]; then mkdir -p ~/src/ioc_scan; fi'"
 
-	#Install netcat and start listening on port 6666
-	echo "Verifying netcat on $instanceName"
-	installNC
-	echo "Begin listening on $instanceName"
-	startListen &
+  #Install netcat and start listening on port 6666
+  echo "Verifying netcat on $instanceName"
+  installNC
+  echo "Begin listening on $instanceName"
+  startListen &
 
-	# Copy latest ioc_scanner.py to target instance
-	curdir=$(pwd)
-	cd "$pydir" || exit
+  # Copy latest ioc_scanner.py to target instance
+  curdir=$(pwd)
+  cd "$pydir" || exit
 
-	echo "Upload lastest ioc_scanner.py to $instanceName"
-	tar czf - ./ioc_scanner.py | nc localhost 5555
+  echo "Upload lastest ioc_scanner.py to $instanceName"
+  tar czf - ./ioc_scanner.py | nc localhost 5555
 
-	cd "$curdir" || exit
+  cd "$curdir" || exit
 
-	# Run ioc_scanner.py on target instance
-	echo "Scan $instanceName for IOC Hashes"
-	AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-		aws --profile="$AWSPROF" --region="$AWS_REGION" \
-		ssm start-session --target="$i" \
-		--document=AWS-StartInteractiveCommand \
-		--parameters="command=python3 ~/src/ioc_scan/ioc_scanner.py" >>"$logfile"
+  # Run ioc_scanner.py on target instance
+  echo "Scan $instanceName for IOC Hashes"
+  AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+    aws --profile="$AWSPROF" --region="$AWS_REGION" \
+    ssm start-session --target="$i" \
+    --document=AWS-StartInteractiveCommand \
+    --parameters="command=python3 ~/src/ioc_scan/ioc_scanner.py" >> "$logfile"
 
-	# Killing port forwading so we can do this again on the next Instance.
-	while pgrep -fq session-manager-plugin; do
-		pkill session-manager-plugin
-		# We need to wait, as some race conditions can occure.
-		sleep 5
-	done
-	echo "------------------------------------------------------------------------" | tee -a "$logfile"
+  # Killing port forwading so we can do this again on the next Instance.
+  while pgrep -fq session-manager-plugin; do
+    pkill session-manager-plugin
+    # We need to wait, as some race conditions can occure.
+    sleep 5
+  done
+  echo "------------------------------------------------------------------------" | tee -a "$logfile"
 done
 
 ##clean up log output for readability
 while grep --quiet --ignore-case "session" "$logfile"; do
-	sed -i '' '/session/d' "$logfile"
+  sed -i '' '/session/d' "$logfile"
 done
 
 sed -i '' 'N;/^\n$/D;P;D;' "$logfile"

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -174,7 +174,7 @@ for i in "${serverList[@]}"; do
   # Killing port forwarding so we can do this again on the next instance.
   while pgrep -fq session-manager-plugin; do
     pkill session-manager-plugin
-    # We need to wait, as some race conditions can occure.
+    # We need to wait, as some race conditions can occur.
     sleep 5
   done
   echo "------------------------------------------------------------------------" | tee -a "$logfile"

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -7,7 +7,7 @@
 #
 # Usage: ./ioc_hash_scan.sh instance-list-file <AWS_PROFILE>
 #
-# Must have AWS_SHARED_CREDENTIALS_FILE and AWS_REGION exported to environmental varialble
+# Must have AWS_SHARED_CREDENTIALS_FILE and AWS_REGION available as environmental variables.
 #
 # Example - Run:
 # export AWS_CREDENTIALS_FILE="$HOME/.aws/credentials" >> "$HOME/.bashrc"

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -95,7 +95,7 @@ function installNC() {
       aws --profile="$AWSPROF" --region="$AWS_REGION" \
       ssm start-session --target="$i" \
       --document=AWS-StartInteractiveCommand \
-      --parameters="command='sudo apt-get install netcat -y'"
+      --parameters="command='sudo apt-get --yes install netcat'"
   else
     AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
       aws --profile="$AWSPROF" --region="$AWS_REGION" \

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -50,7 +50,7 @@ if [ ${#serverList[@]} -eq 0 ]; then
   exit 1
 fi
 
-# Path of aws credentials file
+# Get AWS profile from command line argument
 AWSPROF="$2"
 
 today=$(date +%Y-%m-%d)

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -158,7 +158,7 @@ for i in "${serverList[@]}"; do
   cd "$pydir" || exit
 
   echo "Upload lastest ioc_scanner.py to $instanceName"
-  tar czf - ./ioc_scanner.py | nc localhost 5555
+  tar --create --gzip --file - ./ioc_scanner.py | nc localhost 5555
 
   cd "$curdir" || exit
 

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -151,7 +151,7 @@ for i in "${serverList[@]}"; do
   # Install netcat and start listening on port 6666
   echo "Verifying netcat on $instanceName"
   installNC
-  echo "Begin listening on $instanceName"
+  echo "Begin listening on $instanceName (port 6666)"
   startListen &
 
   # Copy latest ioc_scanner.py to target instance

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -134,7 +134,7 @@ for i in "${serverList[@]}"; do
 
   instanceName=$(getHost)
 
-  echo "Beginning scan of instance $i -- $instanceName" | tee --append "$logfile"
+  echo "Beginning scan of instance $i -- $instanceName" | tee -a "$logfile"
 
   # Start Port Forwarding
   echo "Begining port forwarding"

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -57,7 +57,7 @@ today=$(date +%Y-%m-%d)
 logfile="$HOME/$today-ioc-scanner-hashscan.log"
 
 # Suppress some verbose stdout.
-# Suppress stnderr of pkill command
+# Suppress stderr of pkill command
 exec > >(grep --invert-match 'Starting\|Exiting')
 exec 2> >(grep --invert-match 'SIGTERM')
 

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -7,7 +7,7 @@
 #
 # Usage: ./ioc_hash_scan.sh instance-list-file <AWS_PROFILE>
 #
-# Must have AWS_CREDENTIAL_FILE and AWS_REGION exported to environmental varialble
+# Must have AWS_SHARED_CREDENTIALS_FILE and AWS_REGION exported to environmental varialble
 #
 # Example - Run:
 # export AWS_CREDENTIALS_FILE="$HOME/.aws/credentials" >> "$HOME/.bashrc"
@@ -62,7 +62,7 @@ exec 2> >(grep --invert-match 'SIGTERM')
 
 ## FUNCTIONS
 function getOSType() {
-  OSNAME=$(AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+  OSNAME=$(AWS_SHARED_CREDENTIALS_FILE="$AWS_SHARED_CREDENTIALS_FILE" \
     aws --profile="$AWSPROF" --region="$AWS_REGION" \
     ssm start-session --target="$i" \
     --document=AWS-StartInteractiveCommand \
@@ -72,7 +72,7 @@ function getOSType() {
 }
 
 function getHost() {
-  HOST=$(AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+  HOST=$(AWS_SHARED_CREDENTIALS_FILE="$AWS_SHARED_CREDENTIALS_FILE" \
     aws --profile="$AWSPROF" --region="$AWS_REGION" \
     ssm start-session --target="$i" \
     --document=AWS-StartNonInteractiveCommand \
@@ -82,7 +82,7 @@ function getHost() {
 }
 
 function portForward() {
-  AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+  AWS_SHARED_CREDENTIALS_FILE="$AWS_SHARED_CREDENTIALS_FILE" \
     aws --profile="$AWSPROF" --region="$AWS_REGION" \
     ssm start-session --target="$i" \
     --document=AWS-StartPortForwardingSession --parameters="localPortNumber=5555,portNumber=6666"
@@ -90,13 +90,13 @@ function portForward() {
 
 function installNC() {
   if [[ "$OS" == "Debian" ]]; then
-    AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+    AWS_SHARED_CREDENTIALS_FILE="$AWS_SHARED_CREDENTIALS_FILE" \
       aws --profile="$AWSPROF" --region="$AWS_REGION" \
       ssm start-session --target="$i" \
       --document=AWS-StartInteractiveCommand \
       --parameters="command='sudo apt-get --yes install netcat'"
   else
-    AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+    AWS_SHARED_CREDENTIALS_FILE="$AWS_SHARED_CREDENTIALS_FILE" \
       aws --profile="$AWSPROF" --region="$AWS_REGION" \
       ssm start-session --target="$i" \
       --document=AWS-StartInteractiveCommand \
@@ -106,13 +106,13 @@ function installNC() {
 
 function startListen() {
   if [[ "$OS" == "Debian" ]]; then
-    AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+    AWS_SHARED_CREDENTIALS_FILE="$AWS_SHARED_CREDENTIALS_FILE" \
       aws --profile="$AWSPROF" --region="$AWS_REGION" \
       ssm start-session --target="$i" \
       --document=AWS-StartInteractiveCommand \
       --parameters="command='cd ~/src/ioc_scan; nc -l -p 6666 | tar xzf -'"
   else
-    AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+    AWS_SHARED_CREDENTIALS_FILE="$AWS_SHARED_CREDENTIALS_FILE" \
       aws --profile="$AWSPROF" --region="$AWS_REGION" \
       ssm start-session --target="$i" \
       --document=AWS-StartInteractiveCommand \
@@ -141,7 +141,7 @@ for i in "${serverList[@]}"; do
 
   # Create ~/src/ioc_scan directory on Instance
   echo "Verifying ~/src/ioc_scan directory on $instanceName"
-  AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+  AWS_SHARED_CREDENTIALS_FILE="$AWS_SHARED_CREDENTIALS_FILE" \
     aws --profile="$AWSPROF" --region="$AWS_REGION" \
     ssm start-session --target="$i" \
     --document=AWS-StartInteractiveCommand \
@@ -164,7 +164,7 @@ for i in "${serverList[@]}"; do
 
   # Run ioc_scanner.py on target instance
   echo "Scan $instanceName for IOC Hashes"
-  AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+  AWS_SHARED_CREDENTIALS_FILE="$AWS_SHARED_CREDENTIALS_FILE" \
     aws --profile="$AWSPROF" --region="$AWS_REGION" \
     ssm start-session --target="$i" \
     --document=AWS-StartInteractiveCommand \

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -148,7 +148,7 @@ for i in "${serverList[@]}"; do
     --document=AWS-StartInteractiveCommand \
     --parameters="command='if [ ! -d ~/src/ioc_scan ]; then mkdir --parents ~/src/ioc_scan; fi'"
 
-  #Install netcat and start listening on port 6666
+  # Install netcat and start listening on port 6666
   echo "Verifying netcat on $instanceName"
   installNC
   echo "Begin listening on $instanceName"

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -17,7 +17,7 @@
 # source ~/.bashrc
 #
 # This script assumes that it exists in the ioc-scanner/extras/ directory.
-# If this is different, please edit the variable $pydir to point to 
+# If this is different, please edit the variable $pydir to point to
 # the directory containing ioc_scanner.py
 
 set -o nounset

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -164,7 +164,7 @@ for i in "${serverList[@]}"; do
   cd "$curdir" || exit
 
   # Run ioc_scanner.py on target instance
-  echo "Scan $instanceName for IOC Hashes"
+  echo "Scan $instanceName for IOC hashes"
   AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
     aws --profile="$AWSPROF" --region="$AWS_REGION" \
     ssm start-session --target="$i" \

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -127,7 +127,8 @@ echo "IOC Hash Scan - $today-$(date +%H:%M:%S)" > "$logfile"
 for i in "${serverList[@]}"; do
   OS="$(getOSType)"
   if [[ "$OS" != "Debian" && "$OS" != "Fedora" ]]; then
-    echo "Non-supported OS Type"
+    echo "Instance $i is running an operating system ($OS) that is not supported by this script."
+    echo "Currently only Debian and Fedora are supported - exiting."
     exit 1
   fi
 

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -145,7 +145,7 @@ for i in "${serverList[@]}"; do
     aws --profile="$AWSPROF" --region="$AWS_REGION" \
     ssm start-session --target="$i" \
     --document=AWS-StartInteractiveCommand \
-    --parameters="command='if [ ! -d ~/src/ioc_scan ]; then mkdir -p ~/src/ioc_scan; fi'"
+    --parameters="command='if [ ! -d ~/src/ioc_scan ]; then mkdir --parents ~/src/ioc_scan; fi'"
 
   #Install netcat and start listening on port 6666
   echo "Verifying netcat on $instanceName"

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -117,8 +117,8 @@ function startListen() {
 }
 
 function getSessionID() {
-        SID=$(grep "Connection accepted for session" "$logfile" | tail --lines=1)
-        echo "$SID" | cut -d'[' -f 2 | cut -d']' -f 1
+  SID=$(grep "Connection accepted for session" "$logfile" | tail --lines=1)
+  echo "$SID" | cut -d'[' -f 2 | cut -d']' -f 1
 }
 
 ## MAIN SCRIPT

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -159,7 +159,7 @@ for i in "${serverList[@]}"; do
   cd "$pydir" || exit
 
   echo "Upload lastest ioc_scanner.py to $instanceName"
-  tar --create --gzip --file - ./ioc_scanner.py | nc localhost 5555
+  tar --create --no-xattrs --gzip --file - ./ioc_scanner.py | nc localhost 5555
 
   cd "$curdir" || exit
 

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -17,7 +17,7 @@
 # source ~/.bashrc
 #
 # This script assumes that it exists in the ioc-scanner/extras/ directory.
-# If this is different, please edit the variable $pydir to point to
+# If it does not, please edit the variable $pydir to point to
 # the directory containing ioc_scanner.py
 
 set -o nounset

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+##Add the hashes to the blob at src/ioc_scan/ioc_scanner.py
+
+#
+#  The filename specified in the first argument
+# (instance-list-file) should contain a list of instance id strings, one per line.
+#
+# Usage: ./ioc_hash_scan.sh instance-list-file <AWS_PROFILE>
+#
+# Must have AWS_CREDENTIAL_FILE and AWS_REGION exported to environmental varialble
+#
+# Example - Run:
+# export AWS_CREDENTIALS_FILE="$HOME/.aws/credentials" >> "$HOME/.bashrc"
+# export AWS_REGION="us-east-1" >> "$HOME/.bashrc"
+# Then reload your shell, like
+# source ~/.bashrc
+#
+# This script assumes that it exists in the ioc-scanner/extras/ directory.
+# If this is different, please edit the variable $pydir to point to 
+# the directory containing ioc_scanner.py
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# Directory path of the ioc_scanner.py
+pydir="../src/ioc_scan/"
+
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ] || [ $# -lt 2 ]; then
+        echo Usage: "$0" instance-list-file \<AWS_PROFILE\>
+        exit 1
+fi
+
+# Check if instance list file exists.
+if [ ! -f "$1" ]; then
+        echo Instance List file "$1" does not exist - exiting.
+        exit 1
+fi
+
+# Read instance id strings from file.  [[ -n "$line" ]] handles the case where
+# the last line doesn't end with a newline.
+serverList=()
+while IFS= read -r line || [[ -n "$line" ]]; do
+        serverList+=("$line")
+done <"$1"
+
+if [ ${#serverList[@]} -eq 0 ]; then
+        echo No Instances found in "$1" - exiting.
+        exit 1
+fi
+
+# Path of aws credentials file
+AWSPROF="$2"
+
+today=$(date +%Y-%m-%d)
+logfile="$HOME/$today-ioc-scanner-hashscan.log"
+
+# Suppress some verbose stdout.
+# Suppress stnderr of pkill command
+exec > >(grep --invert-match 'Starting\|Exiting')
+exec 2> >(grep --invert-match 'SIGTERM')
+
+## FUNCTIONS
+function getOSType() {
+        OSNAME=$(AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+                aws --profile="$AWSPROF" --region="$AWS_REGION" \
+                ssm start-session --target="$i" \
+                --document=AWS-StartInteractiveCommand \
+                --parameters="command=cat /etc/os-release | grep --extended-regexp ^NAME=" \
+                --output text)
+        echo "$OSNAME" | grep NAME | cut -d'"' -f2 | cut -d' ' -f1
+}
+
+function getHost() {
+        HOST=$(AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+                aws --profile="$AWSPROF" --region="$AWS_REGION" \
+                ssm start-session --target="$i" \
+                --document=AWS-StartInteractiveCommand \
+                --parameters="command=hostname" \
+                --output text)
+        echo "$HOST" | grep --invert-match "session" | sed '/^$/d'
+}
+
+function portForward() {
+        AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+                aws --profile="$AWSPROF" --region="$AWS_REGION" \
+                ssm start-session --target="$i" \
+                --document=AWS-StartPortForwardingSession --parameters="localPortNumber=5555,portNumber=6666"
+}
+
+function installNC() {
+        if [[ "$OS" == "Debian" ]]; then
+                AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+                        aws --profile="$AWSPROF" --region="$AWS_REGION" \
+                        ssm start-session --target="$i" \
+                        --document=AWS-StartInteractiveCommand \
+                        --parameters="command='sudo apt-get install netcat -y'"
+        else
+                AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+                        aws --profile="$AWSPROF" --region="$AWS_REGION" \
+                        ssm start-session --target="$i" \
+                        --document=AWS-StartInteractiveCommand \
+                        --parameters="command='sudo yum install netcat -y'"
+        fi
+}
+
+function startListen() {
+        if [[ "$OS" == "Debian" ]]; then
+                AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+                        aws --profile="$AWSPROF" --region="$AWS_REGION" \
+                        ssm start-session --target="$i" \
+                        --document=AWS-StartInteractiveCommand \
+                        --parameters="command='cd ~/src/ioc_scan; nc -l -p 6666 | tar xzf -'"
+        else
+                AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+                        aws --profile="$AWSPROF" --region="$AWS_REGION" \
+                        ssm start-session --target="$i" \
+                        --document=AWS-StartInteractiveCommand \
+                        --parameters="command='cd ~/src/ioc_scan; nc -l 6666 | tar xzf -'"
+        fi
+}
+
+## MAIN SCRIPT
+echo "IOC Hash Scan - $today-$(date +%H:%M:%S)" >"$logfile"
+
+for i in "${serverList[@]}"; do
+        OS="$(getOSType)"
+        if [[ "$OS" != "Debian" && "$OS" != "Fedora" ]]; then
+                echo "Non-supported OS Type"
+                exit 1
+        fi
+
+        instanceName=$(getHost)
+
+        echo "Begining scan of Instance $i -- $instanceName" | tee -a "$logfile"
+
+        # Start Port Forwarding
+        echo "Begining port forwarding"
+        portForward &
+
+        # Create ~/src/ioc_scan directory on Instance
+        echo "Verifying ~/src/ioc_scan directory on $instanceName"
+        AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+                aws --profile="$AWSPROF" --region="$AWS_REGION" \
+                ssm start-session --target="$i" \
+                --document=AWS-StartInteractiveCommand \
+                --parameters="command='if [ ! -d ~/src/ioc_scan ]; then mkdir -p ~/src/ioc_scan; fi'"
+
+        #Install netcat and start listening on port 6666
+        echo "Verifying netcat on $instanceName"
+        installNC
+        echo "Begin listening on $instanceName"
+        startListen &
+
+        # Copy latest ioc_scanner.py to target instance
+        curdir=$(pwd)
+        cd "$pydir" || exit
+
+        echo "Upload lastest ioc_scanner.py to $instanceName"
+        tar czf - ./ioc_scanner.py | nc localhost 5555
+
+        cd "$curdir" || exit
+
+        # # Run ioc_scanner.py on target instance
+        # echo "Scan $instanceName for IOC Hashes"
+        # AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+        #         aws --profile="$AWSPROF" --region="$AWS_REGION" \
+        #         ssm start-session --target="$i" \
+        #         --document=AWS-StartInteractiveCommand \
+        #         --parameters="command=python3 ~/src/ioc_scan/ioc_scanner.py" >>"$logfile"
+
+        # Killing port forwading so we can do this again on the next Instance.
+        while pgrep -fq session-manager-plugin; do
+                pkill session-manager-plugin
+                # We need to wait, as some race conditions can occure.
+                sleep 5
+        done
+        echo "------------------------------------------------------------------------" | tee -a "$logfile"
+done
+
+##clean up log output for readability
+while grep --quiet --ignore-case "session" "$logfile"; do
+        sed -i '' '/session/d' "$logfile"
+done
+
+sed -i '' 'N;/^\n$/D;P;D;' "$logfile"
+
+echo "Scan log may be found at: $logfile"

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -110,7 +110,7 @@ function startListen() {
       aws --profile="$AWSPROF" --region="$AWS_REGION" \
       ssm start-session --target="$i" \
       --document=AWS-StartInteractiveCommand \
-      --parameters="command='cd ~/src/ioc_scan; nc -l -p 6666 | tar xzf -'"
+      --parameters="command='cd ~/src/ioc_scan; nc -l -p 6666 | tar --extract --gzip --file -'"
   else
     AWS_SHARED_CREDENTIALS_FILE="$AWS_SHARED_CREDENTIALS_FILE" \
       aws --profile="$AWSPROF" --region="$AWS_REGION" \

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -116,7 +116,7 @@ function startListen() {
       aws --profile="$AWSPROF" --region="$AWS_REGION" \
       ssm start-session --target="$i" \
       --document=AWS-StartInteractiveCommand \
-      --parameters="command='cd ~/src/ioc_scan; nc -l 6666 | tar xzf -'"
+      --parameters="command='cd ~/src/ioc_scan; nc -l 6666 | tar --extract --gzip --file -'"
   fi
 }
 

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -24,7 +24,7 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-# Directory path of the ioc_scanner.py
+# Directory path of the ioc_scanner.py file
 pydir="../src/ioc_scan/"
 
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ] || [ $# -lt 2 ]; then

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -68,9 +68,7 @@ today=$(date +%Y-%m-%d)
 logfile="$HOME/$today-ioc-scanner-hashscan.log"
 
 # Suppress some verbose stdout.
-# Suppress stderr of pkill command
 exec > >(grep --invert-match 'Starting\|Exiting')
-exec 2> >(grep --invert-match 'SIGTERM')
 
 ## FUNCTIONS
 function getOSType() {

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-
+#
 ##Add the hashes to the blob at src/ioc_scan/ioc_scanner.py
-
+#
 #
 #  The filename specified in the first argument
 # (instance-list-file) should contain a list of instance id strings, one per line.

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -39,9 +39,18 @@ fi
 CRED=$(env | grep AWS_SHARED_CREDENTIALS_FILE)
 REG=$(env | grep AWS_REGION)
 PROF=$(env | grep AWS_PROFILE)
-[[ -z "$CRED" ]] && { echo "AWS_SHARED_CREDENTIALS_FILE environmental variable is not set."; exit 1; }
-[[ -z "$REG" ]] && { echo "AWS_REGION environmental variable is not set."; exit 1; }
-[[ -z "$PROF" ]] && { echo "AWS_PROFILE environmental variable is not set."; exit 1; }
+[[ -z "$CRED" ]] && {
+  echo "AWS_SHARED_CREDENTIALS_FILE environmental variable is not set."
+  exit 1
+}
+[[ -z "$REG" ]] && {
+  echo "AWS_REGION environmental variable is not set."
+  exit 1
+}
+[[ -z "$PROF" ]] && {
+  echo "AWS_PROFILE environmental variable is not set."
+  exit 1
+}
 
 # Read instance id strings from file.  [[ -n "$line" ]] handles the case where
 # the last line doesn't end with a newline.

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -137,7 +137,7 @@ for i in "${serverList[@]}"; do
   echo "Beginning scan of instance $i -- $instanceName" | tee -a "$logfile"
 
   # Start Port Forwarding
-  echo "Begining port forwarding"
+  echo "Beginning port forwarding (local port 5555 to remote port 6666)"
   portForward &
 
   # Create ~/src/ioc_scan directory on Instance

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -171,7 +171,7 @@ for i in "${serverList[@]}"; do
     --document=AWS-StartInteractiveCommand \
     --parameters="command=python3 ~/src/ioc_scan/ioc_scanner.py" >> "$logfile"
 
-  # Killing port forwading so we can do this again on the next Instance.
+  # Killing port forwarding so we can do this again on the next instance.
   while pgrep -fq session-manager-plugin; do
     pkill session-manager-plugin
     # We need to wait, as some race conditions can occure.

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -162,13 +162,13 @@ for i in "${serverList[@]}"; do
 
         cd "$curdir" || exit
 
-        # # Run ioc_scanner.py on target instance
-        # echo "Scan $instanceName for IOC Hashes"
-        # AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-        #         aws --profile="$AWSPROF" --region="$AWS_REGION" \
-        #         ssm start-session --target="$i" \
-        #         --document=AWS-StartInteractiveCommand \
-        #         --parameters="command=python3 ~/src/ioc_scan/ioc_scanner.py" >>"$logfile"
+        # Run ioc_scanner.py on target instance
+        echo "Scan $instanceName for IOC Hashes"
+        AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+                aws --profile="$AWSPROF" --region="$AWS_REGION" \
+                ssm start-session --target="$i" \
+                --document=AWS-StartInteractiveCommand \
+                --parameters="command=python3 ~/src/ioc_scan/ioc_scanner.py" >>"$logfile"
 
         # Killing port forwading so we can do this again on the next Instance.
         while pgrep -fq session-manager-plugin; do

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -101,7 +101,7 @@ function installNC() {
       aws --profile="$AWSPROF" --region="$AWS_REGION" \
       ssm start-session --target="$i" \
       --document=AWS-StartInteractiveCommand \
-      --parameters="command='sudo yum install netcat -y'"
+      --parameters="command='sudo dnf --assumeyes install netcat'"
   fi
 }
 

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -28,26 +28,26 @@ set -o pipefail
 pydir="../src/ioc_scan/"
 
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ] || [ $# -lt 2 ]; then
-        echo Usage: "$0" instance-list-file \<AWS_PROFILE\>
-        exit 1
+	echo Usage: "$0" instance-list-file \<AWS_PROFILE\>
+	exit 1
 fi
 
 # Check if instance list file exists.
 if [ ! -f "$1" ]; then
-        echo Instance List file "$1" does not exist - exiting.
-        exit 1
+	echo Instance List file "$1" does not exist - exiting.
+	exit 1
 fi
 
 # Read instance id strings from file.  [[ -n "$line" ]] handles the case where
 # the last line doesn't end with a newline.
 serverList=()
 while IFS= read -r line || [[ -n "$line" ]]; do
-        serverList+=("$line")
+	serverList+=("$line")
 done <"$1"
 
 if [ ${#serverList[@]} -eq 0 ]; then
-        echo No Instances found in "$1" - exiting.
-        exit 1
+	echo No Instances found in "$1" - exiting.
+	exit 1
 fi
 
 # Path of aws credentials file
@@ -63,125 +63,125 @@ exec 2> >(grep --invert-match 'SIGTERM')
 
 ## FUNCTIONS
 function getOSType() {
-        OSNAME=$(AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-                aws --profile="$AWSPROF" --region="$AWS_REGION" \
-                ssm start-session --target="$i" \
-                --document=AWS-StartInteractiveCommand \
-                --parameters="command=cat /etc/os-release | grep --extended-regexp ^NAME=" \
-                --output text)
-        echo "$OSNAME" | grep NAME | cut -d'"' -f2 | cut -d' ' -f1
+	OSNAME=$(AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+		aws --profile="$AWSPROF" --region="$AWS_REGION" \
+		ssm start-session --target="$i" \
+		--document=AWS-StartInteractiveCommand \
+		--parameters="command=cat /etc/os-release | grep --extended-regexp ^NAME=" \
+		--output text)
+	echo "$OSNAME" | grep NAME | cut -d'"' -f2 | cut -d' ' -f1
 }
 
 function getHost() {
-        HOST=$(AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-                aws --profile="$AWSPROF" --region="$AWS_REGION" \
-                ssm start-session --target="$i" \
-                --document=AWS-StartInteractiveCommand \
-                --parameters="command=hostname" \
-                --output text)
-        echo "$HOST" | grep --invert-match "session" | sed '/^$/d'
+	HOST=$(AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+		aws --profile="$AWSPROF" --region="$AWS_REGION" \
+		ssm start-session --target="$i" \
+		--document=AWS-StartInteractiveCommand \
+		--parameters="command=hostname" \
+		--output text)
+	echo "$HOST" | grep --invert-match "session" | sed '/^$/d'
 }
 
 function portForward() {
-        AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-                aws --profile="$AWSPROF" --region="$AWS_REGION" \
-                ssm start-session --target="$i" \
-                --document=AWS-StartPortForwardingSession --parameters="localPortNumber=5555,portNumber=6666"
+	AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+		aws --profile="$AWSPROF" --region="$AWS_REGION" \
+		ssm start-session --target="$i" \
+		--document=AWS-StartPortForwardingSession --parameters="localPortNumber=5555,portNumber=6666"
 }
 
 function installNC() {
-        if [[ "$OS" == "Debian" ]]; then
-                AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-                        aws --profile="$AWSPROF" --region="$AWS_REGION" \
-                        ssm start-session --target="$i" \
-                        --document=AWS-StartInteractiveCommand \
-                        --parameters="command='sudo apt-get install netcat -y'"
-        else
-                AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-                        aws --profile="$AWSPROF" --region="$AWS_REGION" \
-                        ssm start-session --target="$i" \
-                        --document=AWS-StartInteractiveCommand \
-                        --parameters="command='sudo yum install netcat -y'"
-        fi
+	if [[ "$OS" == "Debian" ]]; then
+		AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+			aws --profile="$AWSPROF" --region="$AWS_REGION" \
+			ssm start-session --target="$i" \
+			--document=AWS-StartInteractiveCommand \
+			--parameters="command='sudo apt-get install netcat -y'"
+	else
+		AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+			aws --profile="$AWSPROF" --region="$AWS_REGION" \
+			ssm start-session --target="$i" \
+			--document=AWS-StartInteractiveCommand \
+			--parameters="command='sudo yum install netcat -y'"
+	fi
 }
 
 function startListen() {
-        if [[ "$OS" == "Debian" ]]; then
-                AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-                        aws --profile="$AWSPROF" --region="$AWS_REGION" \
-                        ssm start-session --target="$i" \
-                        --document=AWS-StartInteractiveCommand \
-                        --parameters="command='cd ~/src/ioc_scan; nc -l -p 6666 | tar xzf -'"
-        else
-                AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-                        aws --profile="$AWSPROF" --region="$AWS_REGION" \
-                        ssm start-session --target="$i" \
-                        --document=AWS-StartInteractiveCommand \
-                        --parameters="command='cd ~/src/ioc_scan; nc -l 6666 | tar xzf -'"
-        fi
+	if [[ "$OS" == "Debian" ]]; then
+		AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+			aws --profile="$AWSPROF" --region="$AWS_REGION" \
+			ssm start-session --target="$i" \
+			--document=AWS-StartInteractiveCommand \
+			--parameters="command='cd ~/src/ioc_scan; nc -l -p 6666 | tar xzf -'"
+	else
+		AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+			aws --profile="$AWSPROF" --region="$AWS_REGION" \
+			ssm start-session --target="$i" \
+			--document=AWS-StartInteractiveCommand \
+			--parameters="command='cd ~/src/ioc_scan; nc -l 6666 | tar xzf -'"
+	fi
 }
 
 ## MAIN SCRIPT
 echo "IOC Hash Scan - $today-$(date +%H:%M:%S)" >"$logfile"
 
 for i in "${serverList[@]}"; do
-        OS="$(getOSType)"
-        if [[ "$OS" != "Debian" && "$OS" != "Fedora" ]]; then
-                echo "Non-supported OS Type"
-                exit 1
-        fi
+	OS="$(getOSType)"
+	if [[ "$OS" != "Debian" && "$OS" != "Fedora" ]]; then
+		echo "Non-supported OS Type"
+		exit 1
+	fi
 
-        instanceName=$(getHost)
+	instanceName=$(getHost)
 
-        echo "Begining scan of Instance $i -- $instanceName" | tee -a "$logfile"
+	echo "Begining scan of Instance $i -- $instanceName" | tee -a "$logfile"
 
-        # Start Port Forwarding
-        echo "Begining port forwarding"
-        portForward &
+	# Start Port Forwarding
+	echo "Begining port forwarding"
+	portForward &
 
-        # Create ~/src/ioc_scan directory on Instance
-        echo "Verifying ~/src/ioc_scan directory on $instanceName"
-        AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-                aws --profile="$AWSPROF" --region="$AWS_REGION" \
-                ssm start-session --target="$i" \
-                --document=AWS-StartInteractiveCommand \
-                --parameters="command='if [ ! -d ~/src/ioc_scan ]; then mkdir -p ~/src/ioc_scan; fi'"
+	# Create ~/src/ioc_scan directory on Instance
+	echo "Verifying ~/src/ioc_scan directory on $instanceName"
+	AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+		aws --profile="$AWSPROF" --region="$AWS_REGION" \
+		ssm start-session --target="$i" \
+		--document=AWS-StartInteractiveCommand \
+		--parameters="command='if [ ! -d ~/src/ioc_scan ]; then mkdir -p ~/src/ioc_scan; fi'"
 
-        #Install netcat and start listening on port 6666
-        echo "Verifying netcat on $instanceName"
-        installNC
-        echo "Begin listening on $instanceName"
-        startListen &
+	#Install netcat and start listening on port 6666
+	echo "Verifying netcat on $instanceName"
+	installNC
+	echo "Begin listening on $instanceName"
+	startListen &
 
-        # Copy latest ioc_scanner.py to target instance
-        curdir=$(pwd)
-        cd "$pydir" || exit
+	# Copy latest ioc_scanner.py to target instance
+	curdir=$(pwd)
+	cd "$pydir" || exit
 
-        echo "Upload lastest ioc_scanner.py to $instanceName"
-        tar czf - ./ioc_scanner.py | nc localhost 5555
+	echo "Upload lastest ioc_scanner.py to $instanceName"
+	tar czf - ./ioc_scanner.py | nc localhost 5555
 
-        cd "$curdir" || exit
+	cd "$curdir" || exit
 
-        # Run ioc_scanner.py on target instance
-        echo "Scan $instanceName for IOC Hashes"
-        AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
-                aws --profile="$AWSPROF" --region="$AWS_REGION" \
-                ssm start-session --target="$i" \
-                --document=AWS-StartInteractiveCommand \
-                --parameters="command=python3 ~/src/ioc_scan/ioc_scanner.py" >>"$logfile"
+	# Run ioc_scanner.py on target instance
+	echo "Scan $instanceName for IOC Hashes"
+	AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
+		aws --profile="$AWSPROF" --region="$AWS_REGION" \
+		ssm start-session --target="$i" \
+		--document=AWS-StartInteractiveCommand \
+		--parameters="command=python3 ~/src/ioc_scan/ioc_scanner.py" >>"$logfile"
 
-        # Killing port forwading so we can do this again on the next Instance.
-        while pgrep -fq session-manager-plugin; do
-                pkill session-manager-plugin
-                # We need to wait, as some race conditions can occure.
-                sleep 5
-        done
-        echo "------------------------------------------------------------------------" | tee -a "$logfile"
+	# Killing port forwading so we can do this again on the next Instance.
+	while pgrep -fq session-manager-plugin; do
+		pkill session-manager-plugin
+		# We need to wait, as some race conditions can occure.
+		sleep 5
+	done
+	echo "------------------------------------------------------------------------" | tee -a "$logfile"
 done
 
 ##clean up log output for readability
 while grep --quiet --ignore-case "session" "$logfile"; do
-        sed -i '' '/session/d' "$logfile"
+	sed -i '' '/session/d' "$logfile"
 done
 
 sed -i '' 'N;/^\n$/D;P;D;' "$logfile"

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -76,7 +76,7 @@ function getHost() {
   HOST=$(AWS_SHARED_CREDENTIALS_FILE="$AWS_CREDENTIALS_FILE" \
     aws --profile="$AWSPROF" --region="$AWS_REGION" \
     ssm start-session --target="$i" \
-    --document=AWS-StartInteractiveCommand \
+    --document=AWS-StartNonInteractiveCommand \
     --parameters="command=hostname" \
     --output text)
   echo "$HOST" | grep --invert-match "session" | sed '/^$/d'

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -6,7 +6,12 @@
 # The filename specified in the first argument
 # (instance-list-file) should contain a list of instance id strings, one per line.
 #
-# Usage: AWS_SHARED_CREDENTIALS_FILE=~/.aws/my-creds AWS_REGION=us-east-1 AWS_PROFILE=my-profile ./ioc_hash_scan.sh instance-list-file
+# The following environmental varialbles must be set:
+# AWS_SHARED_CREDENTAILS_FILE
+# AWS_REGION
+# AWS_PROFILE
+#
+# Usage: ./ioc_hash_scan.sh instance-list-file
 #
 # This script assumes that it exists in the ioc-scanner/extras/ directory.
 # If it does not, please edit the variable $pydir to point to
@@ -20,7 +25,7 @@ set -o pipefail
 pydir="../src/ioc_scan/"
 
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ] || [ $# -gt 1 ]; then
-  echo Usage: AWS_SHARED_CREDENTIALS_FILE=~/.aws/my-creds AWS_REGION=us-east-1 AWS_PROFILE=my-profile "$0" instance-list-file
+  echo Usage: "$0" instance-list-file
   exit 1
 fi
 
@@ -29,6 +34,14 @@ if [ ! -f "$1" ]; then
   echo Instance List file "$1" does not exist - exiting.
   exit 1
 fi
+
+# Check if environmental variables are set
+CRED=$(env | grep AWS_SHARED_CREDENTIALS_FILE)
+REG=$(env | grep AWS_REGION)
+PROF=$(env | grep AWS_PROFILE)
+[[ -z "$CRED" ]] && { echo "AWS_SHARED_CREDENTIALS_FILE environmental variable is not set."; exit 1; }
+[[ -z "$REG" ]] && { echo "AWS_REGION environmental variable is not set."; exit 1; }
+[[ -z "$PROF" ]] && { echo "AWS_PROFILE environmental variable is not set."; exit 1; }
 
 # Read instance id strings from file.  [[ -n "$line" ]] handles the case where
 # the last line doesn't end with a newline.

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -154,11 +154,11 @@ for i in "${serverList[@]}"; do
   echo "Begin listening on $instanceName (port 6666)"
   startListen &
 
-  # Copy latest ioc_scanner.py to target instance
+  # Copy ioc_scanner.py to target instance
   curdir=$(pwd)
   cd "$pydir" || exit
 
-  echo "Upload lastest ioc_scanner.py to $instanceName"
+  echo "Upload ioc_scanner.py to $instanceName"
   tar --create --gzip --file - ./ioc_scanner.py | nc localhost 5555
 
   cd "$curdir" || exit

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -180,7 +180,7 @@ for i in "${serverList[@]}"; do
   echo "------------------------------------------------------------------------" | tee -a "$logfile"
 done
 
-##clean up log output for readability
+# Clean up log output for readability
 while grep --quiet --ignore-case "session" "$logfile"; do
   sed -i '' '/session/d' "$logfile"
 done

--- a/extras/ioc_hash_scan.sh
+++ b/extras/ioc_hash_scan.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
-# This script will scan AWS instances occurances of IOC hashes listed in the blob at src/ioc_scan/ioc_scanner.py
+# This script will scan AWS instances for occurrences of IOC hashes listed in
+# the blob at src/ioc_scan/ioc_scanner.py
 #
 # The filename specified in the first argument
 # (instance-list-file) should contain a list of instance id strings, one per line.


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Create extra file to automate the IOC Hash scans.

* This script currently is only valid for Debian and Fedora systems.
* Requires AWS_CREDENTIALS_FILE and AWS_REGION environmental variables to already be set.
* Assumes it will be run from `ioc-scanner/extras`
* Takes a file with a list of instance id's in separate lines
* Requires declaring the AWS_PROFILE as an argument
* Starts port forwarding on the local system. Then it verifies that `netcat` is installed in the instance and starts `netcat` listening on port `6666`. It uploads the latest copy of `ioc_scanner.py` with the latest hashes to the instance. Then it executes `ioc_scanner.py` and directs the output to a local log file.

## 💭 Motivation and context ##

The current process requires manually uploading the `ioc_scanner.py` file to each instance one at a time. This is a laborious method and not scaleable.

## 🧪 Testing ##

This was tested using the default test blobs in `ioc_scanner.py`.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.